### PR TITLE
Update deb2appimage.sh

### DIFF
--- a/deb2appimage.sh
+++ b/deb2appimage.sh
@@ -138,7 +138,7 @@ function getlatestdeb() {
             DEB_DISTRO_URL="debian.org"
             ;;
         Ubuntu|ubuntu)
-            d2aexit 2 "Invalid 'distrorepo' entered in json file" "Ubuntu is not currently supported, sorry"
+            DEB_DISTRO_URL="ubuntu.com"
             ;;
         *)
             d2aexit 2 "Invalid 'distrorepo' entered in json file" "Valid choices are Debian and Ubuntu"


### PR DESCRIPTION
Made ridiculously simple edit (literally just changing the error message outputted to setting the website to ubuntus) to allow for use of ubuntu debs. If I'm being honest you should be ashamed of not having that feature before.